### PR TITLE
Fix issues and improve

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ whitespace	=	()
 (\ f x . f (x x))
 
 # Unbound
-some-func = \ local . true non-existant local
+some-func = \ local . true non-existent local
 
 # Out of scope args
 other-func = \ x . const (\ scoped-arg . x ()) scoped-arg x
@@ -62,7 +62,7 @@ other-func = \ x . const (\ scoped-arg . x ()) scoped-arg x
 (\ f x . f (x x))
 
 # Unbound - Debug
-some-func = \ local . true non-existant local
+some-func = \ local . true non-existent local
 
 # Out of scope args - Debug
 other-func = \ x . const (\ scoped-arg . x ()) scoped-arg x

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
 <form>
 <textarea id="code">
-# Some code (with ignored arguments)
+# Ignored arguments
 false = \ _a b . b
 true = \ a _b . a
 not = \ b . b false true
@@ -43,11 +43,32 @@ true = not false
 # Invalid names
 %value = ()
 
-# Invalid args - unbound
+# Invalid whitespace (tabs)
+whitespace	=	()
+
+# Bare term
+(\ f x . f (x x))
+
+# Unbound
 someFunc = \ local . true nonexistant local
 
-# Invalid args - scoped
+# Out of scope args
 otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
+
+# Debug mode on
+#debug
+
+# Bare term - Debug
+(\ f x . f (x x))
+
+# Unbound - Debug
+someFunc = \ local . true nonexistant local
+
+# Out of scope args - Debug
+otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
+
+# Debug mode off
+#debug
 
 # More code
 zero = false

--- a/index.html
+++ b/index.html
@@ -50,10 +50,10 @@ whitespace	=	()
 (\ f x . f (x x))
 
 # Unbound
-someFunc = \ local . true nonexistant local
+some-func = \ local . true non-existant local
 
 # Out of scope args
-otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
+other-func = \ x . const (\ scoped-arg . x ()) scoped-arg x
 
 # Debug mode on
 #debug
@@ -62,10 +62,10 @@ otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
 (\ f x . f (x x))
 
 # Unbound - Debug
-someFunc = \ local . true nonexistant local
+some-func = \ local . true non-existant local
 
 # Out of scope args - Debug
-otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
+other-func = \ x . const (\ scoped-arg . x ()) scoped-arg x
 
 # Debug mode off
 #debug
@@ -73,7 +73,7 @@ otherFunc = \ x . const (\ scopedArg . x ()) scopedArg x
 # More code
 zero = false
 succ = \ n f x . f (n f x)
-isZ = \ n . n (const false) true
+is-z = \ n . n (const false) true
 add = \ a b f x . a f (b f x)
 mul = \ a b f . a (b f)
 three = succ (succ (succ zero))
@@ -96,15 +96,15 @@ pred = \ n f x . foldr (const f) x (tail (replicate n ())) # Bit janky lol
 map = \ f xs . null xs nil (cons (f (head xs)) (map f (tail xs)))
 sum = foldr add zero
 drop = \ n . n tail
-take = \ n xs . isZ n nil (cons (head xs) (take (pred n) (tail xs)))
+take = \ n xs . is-z n nil (cons (head xs) (take (pred n) (tail xs)))
 col = \ n xs . head (drop n xs)
 colS = \ n xs . cons (col n xs) (cons (col (succ n) xs) (cons (col (succ (succ n)) xs) (nil)))
 row = \ n xs . map (col n) xs
-rowS = \ n xs . cons (row n xs) (cons (row (succ n) xs) (cons (row (succ (succ n)) xs) (nil)))
-chunk = \ a b xs . rowS a (colS b xs)
+row-s = \ n xs . cons (row n xs) (cons (row (succ n) xs) (cons (row (succ (succ n)) xs) (nil)))
+chunk = \ a b xs . row-s a (colS b xs)
 append = \ as bs . null as bs (cons (head as) (append (tail as) bs))
 concat = foldr append nil
-eq = \ a b . isZ a (isZ b) (isZ b false (eq (pred a) (pred b)))
+eq = \ a b . is-z a (is-z b) (is-z b false (eq (pred a) (pred b)))
 all = foldr (\ a b . a b false) true
 allf = \ f xs . all (map f xs)
 </textarea>

--- a/lambdacalc.js
+++ b/lambdacalc.js
@@ -123,8 +123,9 @@ CodeMirror.defineMode("lambdacalc", function(_config, modeConfig) {
     }; },
 
     token: function(stream, state) {
-      if (/\s/.test(stream.peek())) {
-        stream.eatSpace();
+      if (stream.eat(/\t/)) return FAIL;
+      if (/[ \n]/.test(stream.peek())) {
+        stream.eatWhile(/[ \n]/);
         return;
       }
       if (stream.peek() === '#') {

--- a/lambdacalc.js
+++ b/lambdacalc.js
@@ -128,7 +128,7 @@ CodeMirror.defineMode("lambdacalc", function(_config, modeConfig) {
         return;
       }
       if (stream.peek() === '#') {
-        if (stream.match(/^#\s*debug\s*$/))
+        if (stream.match(/^#debug\s*$/))
           state.debug = !state.debug;
         stream.skipToEnd();
         return "comment"

--- a/lambdacalc.js
+++ b/lambdacalc.js
@@ -6,7 +6,7 @@ CodeMirror.defineMode("lambdacalc", function(_config, modeConfig) {
   const BRACKETS = "bracket";
   const LAMBDA = "keyword";
   const DOT = LAMBDA;
-  const PREDEF = "variable";
+  const PREDEF = "text";
   const BOUND = "text";
   const ARGS = "def";
   const HOLE = "atom";

--- a/lambdacalc.js
+++ b/lambdacalc.js
@@ -129,7 +129,7 @@ CodeMirror.defineMode("lambdacalc", function(_config, modeConfig) {
         return;
       }
       if (stream.peek() === '#') {
-        if (stream.match(/^#debug\s*$/))
+        if (stream.match(/^#debug/))
           state.debug = !state.debug;
         stream.skipToEnd();
         return "comment"


### PR DESCRIPTION
Originally the mode had a feature to highlight undefined terms as errors, making debugging easier. However it was overlooked that this breaks (incorrectly highlights) terms which are defined in `preloaded`, or in standalone code-snippets (eg. in kata descriptions).

- Implement `#debug` to enable highlighting undefined terms and bare expressions
- Remove default highlighting of undefined terms and bare expressions
- Add error highlighting of tabs (spaces should be used)
- Updated example